### PR TITLE
Clearable nav caches

### DIFF
--- a/src/Listeners/RebuildStructureCaches.php
+++ b/src/Listeners/RebuildStructureCaches.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Statamic\Listeners;
+
+use Statamic\Events\CollectionSaved;
+use Statamic\Events\CollectionDeleted;
+use Statamic\Events\CollectionTreeSaved;
+use Statamic\Events\CollectionTreeDeleted;
+use Statamic\Events\EntrySaved;
+use Statamic\Events\EntryDeleted;
+use Statamic\Events\NavSaved;
+use Statamic\Events\NavDeleted;
+use Statamic\Events\NavTreeSaved;
+use Statamic\Events\NavTreeDeleted;
+use Statamic\Structures\PageCache;
+
+class RebuildStructureCaches
+{
+    /**
+     * Register the listeners for the subscriber.
+     *
+     * @param  \Illuminate\Events\Dispatcher  $events
+     */
+    public function subscribe($events)
+    {
+        $events->listen([
+            EntryDeleted::class,
+            EntrySaved::class,
+        ], [self::class, 'handleEntryEvents']);
+
+        $events->listen([
+            CollectionDeleted::class,
+            CollectionSaved::class,
+            CollectionTreeDeleted::class,
+            CollectionTreeSaved::class,
+        ], [self::class, 'handleCollectionEvents']);
+
+        $events->listen([
+            NavDeleted::class,
+            NavSaved::class,
+            NavTreeDeleted::class,
+            NavTreeSaved::class,
+        ], [self::class, 'handleNavEvents']);
+    }
+
+    public function handleCollectionEvents($event)
+    {
+        // TODO: All page caches for pages in the collection can be erased
+    }
+
+    public function handleEntryEvents($event)
+    {
+        $entry = $event->entry;
+
+        $page = $entry->collection()->structure()->in($entry->site()->handle())
+            ->flattenedPages()
+            ->where('id', $entry->id())
+            ->first();
+
+        $this->rebuildPageCaches($page);
+    }
+
+    public function handleNavEvents($event)
+    {
+        $tree = $event->tree->tree();
+
+        $event->tree->flattenedPages()->each(function ($page) {
+            $this->rebuildPageCaches($page);
+        });
+    }
+
+    protected function rebuildPageCaches($page)
+    {
+        (new PageCache($page))->rebuildAll([
+            'toAugmentedArray',
+            'urlWithoutRedirect',
+            'absoluteUrl',
+        ]);
+    }
+}

--- a/src/Listeners/RebuildStructureCaches.php
+++ b/src/Listeners/RebuildStructureCaches.php
@@ -2,16 +2,16 @@
 
 namespace Statamic\Listeners;
 
-use Statamic\Events\CollectionSaved;
 use Statamic\Events\CollectionDeleted;
-use Statamic\Events\CollectionTreeSaved;
+use Statamic\Events\CollectionSaved;
 use Statamic\Events\CollectionTreeDeleted;
-use Statamic\Events\EntrySaved;
+use Statamic\Events\CollectionTreeSaved;
 use Statamic\Events\EntryDeleted;
-use Statamic\Events\NavSaved;
+use Statamic\Events\EntrySaved;
 use Statamic\Events\NavDeleted;
-use Statamic\Events\NavTreeSaved;
+use Statamic\Events\NavSaved;
 use Statamic\Events\NavTreeDeleted;
+use Statamic\Events\NavTreeSaved;
 use Statamic\Structures\PageCache;
 
 class RebuildStructureCaches

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -28,5 +28,6 @@ class EventServiceProvider extends ServiceProvider
         \Statamic\Listeners\GeneratePresetImageManipulations::class,
         \Statamic\Listeners\UpdateAssetReferences::class,
         \Statamic\Listeners\UpdateTermReferences::class,
+        \Statamic\Listeners\RebuildStructureCaches::class,
     ];
 }

--- a/src/Structures/PageCache.php
+++ b/src/Structures/PageCache.php
@@ -92,8 +92,8 @@ class PageCache
 
     protected function prebuild(array $methods)
     {
-        foreach ($methods as $method) {
-            $this->get($method);
+        foreach ($methods as $method => $params) {
+            $this->get($method, ...$params);
         }
     }
 

--- a/src/Structures/PageCache.php
+++ b/src/Structures/PageCache.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Statamic\Structures;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class PageCache
+{
+    protected $page;
+    protected $ref;
+    protected $force = false;
+
+    public function __construct(Page $page)
+    {
+        $this->page = $page;
+        $this->ref = $page->reference() ?? $page->id();
+    }
+
+    /**
+     * Call some method on the underlying page, but cache the result
+     */
+    public function get($method, ...$params)
+    {
+        $this->index($method, $params);
+
+        $decorator = Str::camel('get_'.Str::snake($method));
+
+        if (method_exists($this, $decorator)) {
+            return $this->$decorator(...$params);
+        }
+
+        return $this->remember("{$this->indexKey()}:{$method}", fn () => $this->page->$method(...$params));
+    }
+
+    public function rebuildAll(array $prebuild = [])
+    {
+        if (empty($caches = Cache::get($this->indexKey(), [])) && !empty($prebuild)) {
+            $this->prebuild($prebuild);
+
+            return;
+        }
+
+        foreach ($caches as $method => $params) {
+            $this->force()->get($method, ...$params);
+        }
+    }
+
+    public function forgetAll()
+    {
+        foreach (Cache::get($this->indexKey(), []) as $method => $params) {
+            Cache::forget("{$this->indexKey()}:{$method}");
+        }
+
+        Cache::forget($this->indexKey());
+    }
+
+    /**
+     * Keep a tally of all of the different methods we've called, with their parameters,
+     * so we can opportunistically rebuild these caches later
+     */
+    protected function index(string $method, ?array $params = []): void
+    {
+        $cacheKeys = Cache::get($indexKey = $this->indexKey(), []);
+
+        $cacheKeys = ! isset($cacheKeys[$method])
+            ? array_merge($cacheKeys, [$method => $params])
+            : $cacheKeys;
+
+        Cache::put($indexKey, $cacheKeys);
+    }
+
+    protected function indexKey()
+    {
+        return "pages:{$this->ref}";
+    }
+
+    /**
+     * toAugmentedArray is a special case because we need to cache the exact structure as was selected,
+     * so we need to key the cache based
+     */
+    protected function getToAugmentedArray(?array $keys = [])
+    {
+        $cacheKeyPrefix = "{$this->indexKey()}:toAugmentedArray";
+        $selectHash = md5(json_encode($keys ?? []));
+
+        return $this->remember(
+            "{$cacheKeyPrefix}:{$selectHash}",
+            fn () => $this->page->toAugmentedArray($keys)
+        );
+    }
+
+    protected function prebuild(array $methods)
+    {
+        dump($methods);
+        foreach ($methods as $method) {
+            $this->get($method);
+        }
+    }
+
+    protected function remember($key, $callable)
+    {
+        if ($this->force) {
+            Cache::forget($key);
+            $this->force = false;
+        }
+
+        return Cache::rememberForever($key, $callable);
+    }
+
+    protected function force()
+    {
+        $this->force = true;
+
+        return $this;
+    }
+}

--- a/src/Structures/PageCache.php
+++ b/src/Structures/PageCache.php
@@ -18,7 +18,7 @@ class PageCache
     }
 
     /**
-     * Call some method on the underlying page, but cache the result
+     * Call some method on the underlying page, but cache the result.
      */
     public function get($method, ...$params)
     {
@@ -35,7 +35,7 @@ class PageCache
 
     public function rebuildAll(array $prebuild = [])
     {
-        if (empty($caches = Cache::get($this->indexKey(), [])) && !empty($prebuild)) {
+        if (empty($caches = Cache::get($this->indexKey(), [])) && ! empty($prebuild)) {
             $this->prebuild($prebuild);
 
             return;
@@ -57,7 +57,7 @@ class PageCache
 
     /**
      * Keep a tally of all of the different methods we've called, with their parameters,
-     * so we can opportunistically rebuild these caches later
+     * so we can opportunistically rebuild these caches later.
      */
     protected function index(string $method, ?array $params = []): void
     {
@@ -77,7 +77,7 @@ class PageCache
 
     /**
      * toAugmentedArray is a special case because we need to cache the exact structure as was selected,
-     * so we need to key the cache based
+     * so we need to key the cache based.
      */
     protected function getToAugmentedArray(?array $keys = [])
     {
@@ -92,7 +92,6 @@ class PageCache
 
     protected function prebuild(array $methods)
     {
-        dump($methods);
         foreach ($methods as $method) {
             $this->get($method);
         }


### PR DESCRIPTION
This is an extension to https://github.com/statamic/cms/pull/5899

It introduces a `PageCache` class as a convenience and registers a bunch of event handlers.

The intent is to spin through the relevant pages when saving entries or tree structures so that the relevant caches get busted and then rebuilt.

The actual busting and rebuilding seems to work fine via the UI, but there's something funky happening in the world of the test suite that means it's spewing out loads of errors.

I've narrowed this down to the call to `Statamic\Structures\Tree::pages()` which in turn calls `$this->tree()` which then attempts to `build()` the tree (`$this->structure()->validateTree()`) but `structure() === null` for some reason at that point, so... bang 💥 

Basically, if you remove the calls to `pages()` and `flattenedPages()` from `RebuildStructureCaches`, you don't hit this and everything runs smoothly. But as soon as you interrogate the tree, it falls over.

My theory is that this is something to do with being in the middle of saving, but I can't see exactly where the problem is, all of the structures look like they should all the way up to the point of `build()` and `validateTree()`. 🤷🏼 